### PR TITLE
Improvements to action-toolbar

### DIFF
--- a/src/less/actionToolbar.less
+++ b/src/less/actionToolbar.less
@@ -39,6 +39,7 @@
       .transition(e('background-color .1s ease-in'));
       text-decoration: none;
       border:none;
+      outline:none;
 
       &:hover {
         background-color: #3a3a3a;

--- a/src/less/actionToolbar.less
+++ b/src/less/actionToolbar.less
@@ -50,7 +50,7 @@
         }
       }
 
-      &.disabled {
+      &.disabled, :disabled {
         color: #b9b9b9;
         cursor: @cursor-disabled;
 

--- a/src/less/actionToolbar.less
+++ b/src/less/actionToolbar.less
@@ -51,7 +51,8 @@
         }
       }
 
-      &.disabled, :disabled {
+      &.disabled,
+      &:disabled {
         color: #b9b9b9;
         cursor: @cursor-disabled;
 


### PR DESCRIPTION
- Add `outline: none` to `button` and `a` tags to hide the glowing outline after a click
- Add `:disabled` in addition to the `.disabled` selector so that if a button is disabled, it doesn’t *also* need the class set