### PR TITLE
Use Autoprefixer for Automatic Vendor Prefixing

### DIFF
--- a/gulpfile.coffee
+++ b/gulpfile.coffee
@@ -1,4 +1,5 @@
 gulp = require 'gulp'
+autoprefixer = require 'gulp-autoprefixer'
 concat = require 'gulp-concat'
 rename = require 'gulp-rename'
 less = require 'gulp-less'
@@ -25,12 +26,18 @@ gulp.task 'less-concat', ->
   cyclops = gulp.src './src/less/cyclops.less'
     .pipe sourcemaps.init()
     .pipe less()
+    .pipe autoprefixer
+      browsers: [ 'ie >= 9', 'last 2 versions' ]
+      cascade: false
     .pipe sourcemaps.write './'
     .pipe gulp.dest './www/assets/css'
 
   site = gulp.src './src/less/site/site.less'
     .pipe sourcemaps.init()
     .pipe less()
+    .pipe autoprefixer
+      browsers: [ 'ie >= 9', 'last 2 versions' ]
+      cascade: false
     .pipe sourcemaps.write './'
     .pipe gulp.dest './www/assets/css'
 
@@ -40,6 +47,9 @@ gulp.task 'less-min', ->
   return gulp.src './src/less/cyclops.less'
     .pipe sourcemaps.init()
     .pipe less()
+    .pipe autoprefixer
+      browsers: [ 'ie >= 9', 'last 2 versions' ]
+      cascade: false
     .pipe minifyCSS()
     .pipe rename { suffix: '.min' }
     .pipe sourcemaps.write './'

--- a/package.json
+++ b/package.json
@@ -7,10 +7,12 @@
     "start": "gulp dev"
   },
   "author": "CenturyLink Cloud",
-  "licenses": [{
-    "type": "MIT",
-    "url": "http://www.opensource.org/licenses/mit-license.php"
-  }],
+  "licenses": [
+    {
+      "type": "MIT",
+      "url": "http://www.opensource.org/licenses/mit-license.php"
+    }
+  ],
   "engines": {
     "node": "0.10.x",
     "npm": "2.1.x"
@@ -24,6 +26,7 @@
   "devDependencies": {
     "gulp": "^3.9.1",
     "gulp-add-src": "^0.2.0",
+    "gulp-autoprefixer": "^3.1.0",
     "gulp-clean": "^0.3.1",
     "gulp-coffee": "^2.3.1",
     "gulp-concat": "^2.6.0",

--- a/src/less/accountSwitcher.less
+++ b/src/less/accountSwitcher.less
@@ -56,13 +56,13 @@ account-switcher {
     padding: 5px 10px;
     z-index: 1051;
     position: relative;
-    .box-shadow(0 -2px 3px 1px #000);
+    box-shadow: 0 -2px 3px 1px #000;
 
     .toggle-btn {
       padding: 0;
 
       .cyclops-icon use {
-        .transition(e('fill .05s ease-in'));
+        transition: e('fill .05s ease-in');
         fill: @gray-300;
       }
 
@@ -83,7 +83,7 @@ account-switcher {
       white-space: nowrap;
       vertical-align: middle;
       margin-right: 5px;
-      .transition(e('color .05s ease-in'));
+      transition: e('color .05s ease-in');
 
       &:hover {
         color: #fff;
@@ -153,13 +153,13 @@ account-switcher {
       svg {
         margin-bottom: 2px;
         opacity: 0;
-        .transition(e('opacity .05s ease-in'));
+        transition: e('opacity .05s ease-in');
         fill: #fff;
       }
     }
 
     .scroll-area {
-      .box-shadow(inset 0 2px 5px 0 rgba(0, 0, 0, 0.15));
+      box-shadow: inset 0 2px 5px 0 rgba(0, 0, 0, 0.15);
       position: absolute;
       top: 130px;
       bottom: 20px;
@@ -175,7 +175,7 @@ account-switcher {
 
       .list-view-item {
         border-bottom-color: @account-switcher-border-color;
-        .transition(e('color .05s ease-in'));
+        transition: e('color .05s ease-in');
         cursor: pointer;
 
         &.current {

--- a/src/less/actionToolbar.less
+++ b/src/less/actionToolbar.less
@@ -34,7 +34,7 @@
       background-color: @action-toolbar-bg;
       display: inline-block;
       padding: 8px 10px 12px;
-      .transition(e('color .15s ease-in, padding .15s ease-in, background-color .15s ease-in'));
+      transition: e('color .15s ease-in, padding .15s ease-in, background-color .15s ease-in');
       text-decoration: none;
       border:none;
       outline:none;
@@ -44,7 +44,7 @@
         color: #fff;
 
         svg.cyclops-icon {
-          .transition(e('fill .15s'));
+          transition: e('fill .15s');
           fill: #fff;
         }
       }
@@ -126,7 +126,7 @@
     background: @action-toolbar-dropdown-bg;
     border: 0;
     margin-top: 0;
-    .border-radius(0);
+    border-radius: 0;
 
     li a,
     li button {

--- a/src/less/alerts.less
+++ b/src/less/alerts.less
@@ -9,7 +9,7 @@
   padding: @alert-padding;
   margin-bottom: @line-height-computed;
   border: 1px solid transparent;
-  .border-radius(@alert-border-radius);
+  border-radius: @alert-border-radius;
   text-align: center;
 
   // Headings for larger alerts
@@ -67,7 +67,7 @@
 // Alert banner for top level (under the main nav) notifications
 
 .alert-banner {
-  .border-radius(0);
+  border-radius: 0;
   font-weight: @font-weight-bold;
   border-left: none;
   border-right: none;

--- a/src/less/animation/fadeIn.less
+++ b/src/less/animation/fadeIn.less
@@ -1,26 +1,8 @@
-@-webkit-keyframes fadeIn {
-	0% {opacity: 0;}
-	100% {opacity: 1;}
-}
-
-@-moz-keyframes fadeIn {
-	0% {opacity: 0;}
-	100% {opacity: 1;}
-}
-
-@-o-keyframes fadeIn {
-	0% {opacity: 0;}
-	100% {opacity: 1;}
-}
-
 @keyframes fadeIn {
 	0% {opacity: 0;}
 	100% {opacity: 1;}
 }
 
 .fadeIn {
-	-webkit-animation-name: fadeIn;
-	-moz-animation-name: fadeIn;
-	-o-animation-name: fadeIn;
 	animation-name: fadeIn;
 }

--- a/src/less/animation/fadeInLeft.less
+++ b/src/less/animation/fadeInLeft.less
@@ -1,39 +1,3 @@
-@-webkit-keyframes fadeInLeft {
-	0% {
-		opacity: 0;
-		-webkit-transform: translateX(-20px);
-	}
-
-	100% {
-		opacity: 1;
-		-webkit-transform: translateX(0);
-	}
-}
-
-@-moz-keyframes fadeInLeft {
-	0% {
-		opacity: 0;
-		-moz-transform: translateX(-20px);
-	}
-
-	100% {
-		opacity: 1;
-		-moz-transform: translateX(0);
-	}
-}
-
-@-o-keyframes fadeInLeft {
-	0% {
-		opacity: 0;
-		-o-transform: translateX(-20px);
-	}
-
-	100% {
-		opacity: 1;
-		-o-transform: translateX(0);
-	}
-}
-
 @keyframes fadeInLeft {
 	0% {
 		opacity: 0;
@@ -47,8 +11,5 @@
 }
 
 .fadeInLeft {
-	-webkit-animation-name: fadeInLeft;
-	-moz-animation-name: fadeInLeft;
-	-o-animation-name: fadeInLeft;
 	animation-name: fadeInLeft;
 }

--- a/src/less/animation/pulsate.less
+++ b/src/less/animation/pulsate.less
@@ -1,45 +1,3 @@
-@-webkit-keyframes pulsate {
-  0% {
-    opacity: 0.3;
-  }
-
-  50% {
-    opacity: 1.0;
-  }
-
-  100% {
-    opacity: 0.3;
-  }
-}
-
-@-moz-keyframes pulsate {
-  0% {
-    opacity: 0.3;
-  }
-
-  50% {
-    opacity: 1.0;
-  }
-
-  100% {
-    opacity: 0.3;
-  }
-}
-
-@-o-keyframes pulsate {
-  0% {
-    opacity: 0.3;
-  }
-
-  50% {
-    opacity: 1.0;
-  }
-
-  100% {
-    opacity: 0.3;
-  }
-}
-
 @keyframes pulsate {
   0% {
     opacity: 0.3;
@@ -55,7 +13,7 @@
 }
 
 .pulsate {
-  -webkit-animation: pulsate 1.5s ease-out;
-  -webkit-animation-iteration-count: infinite;
+  animation: pulsate 1.5s ease-out;
+  animation-iteration-count: infinite;
   opacity: 0.3;
 }

--- a/src/less/buttons.less
+++ b/src/less/buttons.less
@@ -1,8 +1,8 @@
 .btn {
   background-image: none;
   border: none;
-  .border-radius(@border-radius-small);
-  .box-shadow(none);
+  border-radius: @border-radius-small;
+  box-shadow: none;
   color: #fff;
   display: inline-block;
   font-family: @font-family;
@@ -13,10 +13,10 @@
   padding: 4px 10px 6px;
   text-shadow: none;
   text-decoration: none;
-  .transition(e('background-color .1s, color .1s, opacity .1s, border .1s'));
+  transition: e('background-color .1s, color .1s, opacity .1s, border .1s');
 
   &:active {
-    .box-shadow(inset 0 2px 1px 0 rgba(0,0,0,0.2));
+    box-shadow: inset 0 2px 1px 0 rgba(0,0,0,0.2);
   }
 
   &:focus {
@@ -28,7 +28,7 @@
   &.disabled {
     opacity: 0.65;
     cursor: @cursor-disabled;
-    .box-shadow(none);
+    box-shadow: none;
   }
 
   .cyclops-icon use {
@@ -39,7 +39,7 @@
 fieldset[disabled] {
   .btn {
     cursor: @cursor-disabled;
-    .box-shadow(none);
+    box-shadow: none;
   }
 
   .btn-default {
@@ -237,7 +237,7 @@ fieldset[disabled] {
   font-size: @font-size-regular;
   background: none;
   border: none;
-  .box-shadow(none);
+  box-shadow: none;
   letter-spacing: 0;
   margin-top: -3px;
   padding: 0;
@@ -249,7 +249,7 @@ fieldset[disabled] {
   }
 
   &:active {
-    .box-shadow(none);
+    box-shadow: none;
   }
 
   &:focus {
@@ -272,7 +272,7 @@ fieldset[disabled] {
   }
 
   &:active {
-    .box-shadow(none);
+    box-shadow: none;
   }
 
   &:focus {
@@ -290,7 +290,7 @@ fieldset[disabled] {
 
 .btn-lg,
 .btn-large {
-  .border-radius(@border-radius-small);
+  border-radius: @border-radius-small;
   font-size: 15px;
   line-height: 20px;
   padding: 6px 10px 9px;
@@ -302,7 +302,7 @@ fieldset[disabled] {
 
 .btn-sm,
 .btn-small {
-  .border-radius(@border-radius-small);
+  border-radius: @border-radius-small;
   font-size: 12px;
   line-height: 18px;
   padding: 3px 8px 4px;
@@ -313,7 +313,7 @@ fieldset[disabled] {
 }
 
 .btn-mini {
-  .border-radius(@border-radius-small);
+  border-radius: @border-radius-small;
   font-size: 11px;
   line-height: 12px;
   text-decoration: none;
@@ -325,7 +325,7 @@ fieldset[disabled] {
 }
 
 .btn-group > .btn {
-  .border-radius(@border-radius-small);
+  border-radius: @border-radius-small;
 }
 
 .btn-row > .btn {
@@ -338,7 +338,7 @@ fieldset[disabled] {
   .btn-link();
   background: none;
   border: none;
-  .box-shadow(none);
+  box-shadow: none;
   letter-spacing: 0;
   margin-top: -3px;
   padding: 0;
@@ -353,7 +353,7 @@ fieldset[disabled] {
   width: 100%;
   padding-left: 0;
   padding-right: 0;
-  .box-sizing(border-box);
+  box-sizing: border-box;
 }
 
 // Vertically space out multiple block buttons
@@ -395,5 +395,5 @@ button.close {
   cursor: pointer;
   background: transparent;
   border: 0;
-  -webkit-appearance: none;
+  appearance: none;
 }

--- a/src/less/cards.less
+++ b/src/less/cards.less
@@ -6,7 +6,7 @@
   margin-bottom: @line-height-computed;
   background-color: #fff;
   border: 1px solid @border-color;
-  .border-radius(@border-radius-base);
+  border-radius: @border-radius-base;
 
   .new-list-view > li:last-child {
 
@@ -20,7 +20,7 @@
 
   > .alert {
     border: none;
-    .border-radius(0);
+    border-radius: 0;
     margin-bottom: 0;
   }
 }
@@ -81,7 +81,7 @@
   left: 0;
   padding: 15px 15px;
   background-color: rgba(0,0,0, .8);
-  .border-radius(@border-radius-base);
+  border-radius: @border-radius-base;
 
   .card-title {
     margin-bottom: @line-height-computed / 2;

--- a/src/less/charts.less
+++ b/src/less/charts.less
@@ -16,138 +16,74 @@
 .ct-chart-line .ct-label,
 .ct-chart-bar .ct-label {
   display: block;
-  display: -webkit-box;
-  display: -moz-box;
-  display: -ms-flexbox;
-  display: -webkit-flex;
   display: flex;
 }
 
 .ct-label.ct-horizontal.ct-start {
-  -webkit-box-align: flex-end;
-  -webkit-align-items: flex-end;
-  -ms-flex-align: flex-end;
   align-items: flex-end;
-  -webkit-box-pack: flex-start;
-  -webkit-justify-content: flex-start;
-  -ms-flex-pack: flex-start;
   justify-content: flex-start;
   text-align: left;
   text-anchor: start;
 }
 
 .ct-label.ct-horizontal.ct-end {
-  -webkit-box-align: flex-start;
-  -webkit-align-items: flex-start;
-  -ms-flex-align: flex-start;
   align-items: flex-start;
-  -webkit-box-pack: flex-start;
-  -webkit-justify-content: flex-start;
-  -ms-flex-pack: flex-start;
   justify-content: flex-start;
   text-align: left;
   text-anchor: start;
 }
 
 .ct-label.ct-vertical.ct-start {
-  -webkit-box-align: flex-end;
-  -webkit-align-items: flex-end;
-  -ms-flex-align: flex-end;
   align-items: flex-end;
-  -webkit-box-pack: flex-end;
-  -webkit-justify-content: flex-end;
-  -ms-flex-pack: flex-end;
   justify-content: flex-end;
   text-align: right;
   text-anchor: end;
 }
 
 .ct-label.ct-vertical.ct-end {
-  -webkit-box-align: flex-end;
-  -webkit-align-items: flex-end;
-  -ms-flex-align: flex-end;
   align-items: flex-end;
-  -webkit-box-pack: flex-start;
-  -webkit-justify-content: flex-start;
-  -ms-flex-pack: flex-start;
   justify-content: flex-start;
   text-align: left;
   text-anchor: start;
 }
 
 .ct-chart-bar .ct-label.ct-horizontal.ct-start {
-  -webkit-box-align: flex-end;
-  -webkit-align-items: flex-end;
-  -ms-flex-align: flex-end;
   align-items: flex-end;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
   justify-content: center;
   text-align: center;
   text-anchor: start;
 }
 
 .ct-chart-bar .ct-label.ct-horizontal.ct-end {
-  -webkit-box-align: flex-start;
-  -webkit-align-items: flex-start;
-  -ms-flex-align: flex-start;
   align-items: flex-start;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
   justify-content: center;
   text-align: center;
   text-anchor: start;
 }
 
 .ct-chart-bar.ct-horizontal-bars .ct-label.ct-horizontal.ct-start {
-  -webkit-box-align: flex-end;
-  -webkit-align-items: flex-end;
-  -ms-flex-align: flex-end;
   align-items: flex-end;
-  -webkit-box-pack: flex-start;
-  -webkit-justify-content: flex-start;
-  -ms-flex-pack: flex-start;
   justify-content: flex-start;
   text-align: left;
   text-anchor: start;
 }
 
 .ct-chart-bar.ct-horizontal-bars .ct-label.ct-horizontal.ct-end {
-  -webkit-box-align: flex-start;
-  -webkit-align-items: flex-start;
-  -ms-flex-align: flex-start;
   align-items: flex-start;
-  -webkit-box-pack: flex-start;
-  -webkit-justify-content: flex-start;
-  -ms-flex-pack: flex-start;
   justify-content: flex-start;
   text-align: left;
   text-anchor: start;
 }
 
 .ct-chart-bar.ct-horizontal-bars .ct-label.ct-vertical.ct-start {
-  -webkit-box-align: center;
-  -webkit-align-items: center;
-  -ms-flex-align: center;
   align-items: center;
-  -webkit-box-pack: flex-end;
-  -webkit-justify-content: flex-end;
-  -ms-flex-pack: flex-end;
   justify-content: flex-end;
   text-align: right;
   text-anchor: end;
 }
 
 .ct-chart-bar.ct-horizontal-bars .ct-label.ct-vertical.ct-end {
-  -webkit-box-align: center;
-  -webkit-align-items: center;
-  -ms-flex-align: center;
   align-items: center;
-  -webkit-box-pack: flex-start;
-  -webkit-justify-content: flex-start;
-  -ms-flex-pack: flex-start;
   justify-content: flex-start;
   text-align: left;
   text-anchor: end;

--- a/src/less/dateTimePicker.less
+++ b/src/less/dateTimePicker.less
@@ -42,7 +42,7 @@
   background: @gray-700;
 
   &.ui-corner-all {
-    .border-radius(@border-radius-base);
+    border-radius: @border-radius-base;
   }
 
   .ui-datepicker-header {
@@ -132,7 +132,7 @@
         text-align: center;
         text-decoration: none;
         color: @gray-300;
-        .transition(e('background .1s ease-in, color .1s'));
+        transition: e('background .1s ease-in, color .1s');
         &:hover {
           background-color: #fff;
           color: @gray-700;

--- a/src/less/dropdown.less
+++ b/src/less/dropdown.less
@@ -27,7 +27,7 @@ div.dropdown {
     text-align: left; // Ensures proper alignment if parent has it changed (e.g., modal footer)
     background-color: #fff;
     border: 1px solid @border-color;
-    .border-radius(@border-radius-small);
+    border-radius: @border-radius-small;
     background-clip: padding-box;
 
     &.dropdown-menu-right {

--- a/src/less/forms.less
+++ b/src/less/forms.less
@@ -38,7 +38,7 @@ label {
 // address browser inconsistencies.
 // Override content-box in Normalize (* isn't specific enough)
 input[type="search"] {
-  .box-sizing(border-box);
+  box-sizing: border-box;
 }
 // Position radios and checkboxes better
 input[type="radio"],
@@ -72,7 +72,7 @@ select[size] {
   background-color: #fff;
   background-image: none;
   border: 1px solid @gray-200;
-  .border-radius(@border-radius-base);
+  border-radius: @border-radius-base;
   transition: border-color ease-in-out 0.15s, box-shadow ease-in-out 0.15s;
   // Disabled and read-only inputs
   //

--- a/src/less/grid.less
+++ b/src/less/grid.less
@@ -9,15 +9,11 @@
 */
 /*! normalize.css v3.0.2 | MIT License | git.io/normalize */
 * {
-  -webkit-box-sizing: border-box;
-  -moz-box-sizing: border-box;
   box-sizing: border-box;
 }
 
 *:before,
 *:after {
-  -webkit-box-sizing: border-box;
-  -moz-box-sizing: border-box;
   box-sizing: border-box;
 }
 

--- a/src/less/listview.less
+++ b/src/less/listview.less
@@ -72,7 +72,7 @@
     .list-view-read-only-item {
       border-bottom: 1px solid @border-color;
       padding: 10px 0;
-      .transition(e('background .05s ease-in'));
+      transition: e('background .05s ease-in');
       .clearfix();
 
       &.no-hover {
@@ -108,7 +108,7 @@
       .new-list-view-actions {
         text-align: right;
         opacity: 0;
-        .transition(e('opacity .1s linear'));
+        transition: e('opacity .1s linear');
       }
 
       &:hover .new-list-view-actions {
@@ -335,7 +335,7 @@
 .list-view-item-form {
   background: #f5f5f5;
   border: 1px solid @gray-100;
-  .box-shadow(inset 0 0 5px 0 rgba(0,0,0,.1) );
+  box-shadow: inset 0 0 5px 0 rgba(0,0,0,.1);
   padding: 10px 20px;
 
   .validation-summary {
@@ -462,7 +462,7 @@
     color: @text-color;
 
     &:focus {
-      .box-shadow(none);
+      box-shadow: none;
     }
   }
 }

--- a/src/less/mainNav.less
+++ b/src/less/mainNav.less
@@ -8,7 +8,7 @@ main-nav {
   z-index: @zindex-main-nav;
   background: @main-nav-bg;
   box-shadow: inset 0 1px 0 0 rgba(0,0,0,.3); //top border
-  .transition(width .5s);
+  transition: width .5s;
   color: @main-nav-text;
 
   // Prevent a BUFOC
@@ -19,7 +19,7 @@ main-nav {
     bottom: 0;
     width: @main-nav-width-sm;
     background: @main-nav-bg;
-    .transition(width .5s);
+    transition: width .5s;
     z-index: -1;
   }
 
@@ -53,7 +53,7 @@ main-nav {
     height: 20px;
 
     use {
-      .transition(fill .2s);
+      transition: fill .2s;
       fill: @main-nav-icon-color;
     }
   }
@@ -63,7 +63,7 @@ main-nav {
     padding: 10px 0;
     width: 100%;
     background-color: transparent;
-    .border-radius(0);
+    border-radius: 0;
     color: @main-nav-link-text;
     font-size: @font-size-small;
     overflow: hidden;
@@ -80,14 +80,14 @@ main-nav {
       .cyclops-icon use {
         fill: @main-nav-link-text-hover;
       }
-    }f
+    }
 
     &:active {
-      box-shadow: none;
       outline: none;
       background-color: @main-nav-active-bg;
       color: @main-nav-link-text-active;
-      .box-shadow(inset 0 0 3px 0 rgba(0,0,0,.3));
+      box-shadow: inset 0 0 3px 0 rgba(0,0,0,.3);
+      transform: scale(.985,.985);
 
       .cyclops-icon use {
         fill: @main-nav-link-text-active;
@@ -152,7 +152,7 @@ main-nav {
   list-style: none;
 
   li {
-    .transition(background-color .2s, width .2s, height .2s;);
+    transition: background-color .2s, width .2s, height .2s;
     border-bottom: 1px solid @gray-900;
     width: @main-nav-width-sm;
     height: 44px;
@@ -194,7 +194,7 @@ main-nav {
   background: @main-nav-flyout-bg;
   border-right: 1px solid #202220;
   margin-left: -1 * @main-nav-flyout-width;
-  .transition(margin-left .5s);
+  transition: margin-left .5s;
   box-shadow: 0 0 7px #000;
   overflow-y: auto;
 
@@ -251,7 +251,7 @@ main-nav {
     height: auto;
     overflow: hidden;
     margin: 0;
-    .transition(background .2s);
+    transition: background .2s;
 
     &.selected,
     &.selected:hover {

--- a/src/less/mixins.less
+++ b/src/less/mixins.less
@@ -28,175 +28,7 @@
   margin-right: floor((@gutter / -2));
   .clearfix();
 }
-// CSS3 PROPERTIES
-// --------------------------------------------------
-// Border Radius
 
-.border-radius(@radius) {
-  -webkit-border-radius: @radius;
-  -moz-border-radius: @radius;
-  border-radius: @radius;
-}
-// Single Corner Border Radius
-
-.border-top-left-radius(@radius) {
-  -webkit-border-top-left-radius: @radius;
-  -moz-border-radius-topleft: @radius;
-  border-top-left-radius: @radius;
-}
-
-.border-top-right-radius(@radius) {
-  -webkit-border-top-right-radius: @radius;
-  -moz-border-radius-topright: @radius;
-  border-top-right-radius: @radius;
-}
-
-.border-bottom-right-radius(@radius) {
-  -webkit-border-bottom-right-radius: @radius;
-  -moz-border-radius-bottomright: @radius;
-  border-bottom-right-radius: @radius;
-}
-
-.border-bottom-left-radius(@radius) {
-  -webkit-border-bottom-left-radius: @radius;
-  -moz-border-radius-bottomleft: @radius;
-  border-bottom-left-radius: @radius;
-}
-// Single Side Border Radius
-
-.border-top-radius(@radius) {
-  .border-top-right-radius(@radius);
-  .border-top-left-radius(@radius);
-}
-
-.border-right-radius(@radius) {
-  .border-top-right-radius(@radius);
-  .border-bottom-right-radius(@radius);
-}
-
-.border-bottom-radius(@radius) {
-  .border-bottom-right-radius(@radius);
-  .border-bottom-left-radius(@radius);
-}
-
-.border-left-radius(@radius) {
-  .border-top-left-radius(@radius);
-  .border-bottom-left-radius(@radius);
-}
-// Drop shadows
-
-.box-shadow(@shadow) {
-  -webkit-box-shadow: @shadow;
-  -moz-box-shadow: @shadow;
-  box-shadow: @shadow;
-}
-
-.gradient (@startColor: #eee, @endColor: #fff) {
-  background-color: @startColor;
-  background: -webkit-gradient(linear, left top, left bottom, from(@startColor), to(@endColor));
-  background: -webkit-linear-gradient(top, @startColor, @endColor);
-  background: -moz-linear-gradient(top, @startColor, @endColor);
-  background: -ms-linear-gradient(top, @startColor, @endColor);
-  background: -o-linear-gradient(top, @startColor, @endColor);
-}
-
-.horizontal-gradient (@startColor: #eee, @endColor: #fff) {
-  background-color: @startColor;
-  background-image: -webkit-gradient(linear, left top, right top, from(@startColor), to(@endColor));
-  background-image: -webkit-linear-gradient(left, @startColor, @endColor);
-  background-image: -moz-linear-gradient(left, @startColor, @endColor);
-  background-image: -ms-linear-gradient(left, @startColor, @endColor);
-  background-image: -o-linear-gradient(left, @startColor, @endColor);
-}
-// Transitions
-
-.transition(@transition) {
-  -webkit-transition: @transition;
-  -moz-transition: @transition;
-  -o-transition: @transition;
-  transition: @transition;
-}
-
-.transition-delay(@transition-delay) {
-  -webkit-transition-delay: @transition-delay;
-  -moz-transition-delay: @transition-delay;
-  -o-transition-delay: @transition-delay;
-  transition-delay: @transition-delay;
-}
-// Transformations
-
-.rotate(@degrees) {
-  -webkit-transform: rotate(@degrees);
-  -moz-transform: rotate(@degrees);
-  -ms-transform: rotate(@degrees);
-  -o-transform: rotate(@degrees);
-  transform: rotate(@degrees);
-}
-
-.scale(@ratio) {
-  -webkit-transform: scale(@ratio);
-  -moz-transform: scale(@ratio);
-  -ms-transform: scale(@ratio);
-  -o-transform: scale(@ratio);
-  transform: scale(@ratio);
-}
-
-.translate(@x, @y) {
-  -webkit-transform: translate(@x, @y);
-  -moz-transform: translate(@x, @y);
-  -ms-transform: translate(@x, @y);
-  -o-transform: translate(@x, @y);
-  transform: translate(@x, @y);
-}
-
-.skew(@x, @y) {
-  -webkit-transform: skew(@x, @y);
-  -moz-transform: skew(@x, @y);
-  -ms-transform: skewX(@x) skewY(@y); // See https://github.com/twitter/bootstrap/issues/4885
-  -o-transform: skew(@x, @y);
-  transform: skew(@x, @y);
-  -webkit-backface-visibility: hidden; // See https://github.com/twitter/bootstrap/issues/5319
-}
-
-.translate3d(@x, @y, @z) {
-  -webkit-transform: translate3d(@x, @y, @z);
-  -moz-transform: translate3d(@x, @y, @z);
-  -o-transform: translate3d(@x, @y, @z);
-  transform: translate3d(@x, @y, @z);
-}
-// Backface visibility
-// Prevent browsers from flickering when using CSS 3D transforms.
-// Default value is `visible`, but can be changed to `hidden
-// See git pull https://github.com/dannykeane/bootstrap.git backface-visibility for examples
-
-.backface-visibility(@visibility) {
-  -webkit-backface-visibility: @visibility;
-  -moz-backface-visibility: @visibility;
-  backface-visibility: @visibility;
-}
-// Background clipping
-// Heads up: FF 3.6 and under need "padding" instead of "padding-box"
-
-.background-clip(@clip) {
-  -webkit-background-clip: @clip;
-  -moz-background-clip: @clip;
-  background-clip: @clip;
-}
-// Background sizing
-
-.background-size(@size) {
-  -webkit-background-size: @size;
-  -moz-background-size: @size;
-  -o-background-size: @size;
-  background-size: @size;
-}
-// Box sizing
-
-.box-sizing(@boxmodel) {
-  -webkit-box-sizing: @boxmodel;
-  -moz-box-sizing: @boxmodel;
-  box-sizing: @boxmodel;
-}
 // input text placeholder {
 
 .placeholder (@color) {
@@ -212,16 +44,6 @@
     color: @color;
   }
 }
-// User select
-// For selecting text on the page
-
-.user-select(@select) {
-  -webkit-user-select: @select;
-  -moz-user-select: @select;
-  -ms-user-select: @select;
-  -o-user-select: @select;
-  user-select: @select;
-}
 // Resize anything
 
 .resizable(@direction) {
@@ -231,21 +53,13 @@
 // CSS3 Content Columns
 
 .content-columns(@columnCount, @columnGap: @gridGutterWidth) {
-  -webkit-column-count: @columnCount;
-  -moz-column-count: @columnCount;
   column-count: @columnCount;
-  -webkit-column-gap: @columnGap;
-  -moz-column-gap: @columnGap;
   column-gap: @columnGap;
 }
 // Optional hyphenation
 
 .hyphens(@mode: auto) {
   word-wrap: break-word;
-  -webkit-hyphens: @mode;
-  -moz-hyphens: @mode;
-  -ms-hyphens: @mode;
-  -o-hyphens: @mode;
   hyphens: @mode;
 }
 

--- a/src/less/navbar.less
+++ b/src/less/navbar.less
@@ -17,7 +17,7 @@
   &:extend(.clearfix all);
 
   @media (min-width: @grid-float-breakpoint) {
-    .border-radius(@navbar-border-radius);
+    border-radius: @navbar-border-radius;
   }
 }
 
@@ -98,7 +98,7 @@
     border-top: 1px solid @nav-bottom-border;
     border-bottom: 1px solid @nav-bottom-border;
     text-align: left;
-    .border-radius(0);
+    border-radius: 0;
     font-weight: @font-weight-bold;
     text-transform: uppercase;
     font-size: @font-size-regular - 1;
@@ -110,7 +110,7 @@
     &.open {
       background-color: @nav-link-hover-bg;
       .cyclops-icon {
-        .rotate(180deg);
+        transform: rotate(180deg);
       }
     }
 
@@ -147,7 +147,7 @@
 
   .dropdown.open {
     .cyclops-icon {
-      .rotate(180deg);
+      transform: rotate(180deg);
     }
   }
 
@@ -164,7 +164,7 @@
   @media (min-width: @grid-float-breakpoint) {
     .clearfix();
     display: block;
-    .border-radius(0);
+    border-radius: 0;
     border-bottom: 1px solid @border-color;
 
     .navbar-nav {
@@ -187,7 +187,7 @@
         }
 
         > a {
-          .border-radius(@border-radius-small);
+          border-radius: @border-radius-small;
           padding: 6px 13px 6px 15px;
         }
       }
@@ -195,7 +195,7 @@
 
     .dropdown.open {
       .cyclops-icon {
-        .rotate(0);
+        transform: rotate(0);
       }
     }
 
@@ -243,7 +243,7 @@
   border-width: 0 0 1px;
 
   @media (min-width: @grid-float-breakpoint) {
-    .border-radius(0);
+    border-radius: 0;
   }
 }
 
@@ -306,7 +306,7 @@
   background-color: transparent;
   background-image: none; // Reset unusual Firefox-on-Android default style; see https://github.com/necolas/normalize.css/issues/214
   border: 1px solid transparent;
-  .border-radius(@border-radius-base);
+  border-radius: @border-radius-base;
 
   // We remove the `outline` here, but later compensate by attaching `:hover`
   // styles to `:focus`.
@@ -320,7 +320,7 @@
     display: block;
     width: 22px;
     height: 2px;
-    .border-radius(1px);
+    border-radius: 1px;
   }
 
   .icon-bar + .icon-bar {

--- a/src/less/normalize.less
+++ b/src/less/normalize.less
@@ -8,8 +8,7 @@
 
 html {
   font-family: sans-serif; // 1
-  -ms-text-size-adjust: 100%; // 2
-  -webkit-text-size-adjust: 100%; // 2
+  text-size-adjust: 100%; // 2
 }
 
 //
@@ -291,7 +290,7 @@ button,
 html input[type="button"], // 1
 input[type="reset"],
 input[type="submit"] {
-  -webkit-appearance: button; // 2
+  appearance: button; // 2
   cursor: pointer; // 3
 }
 
@@ -354,7 +353,7 @@ input[type="number"]::-webkit-outer-spin-button {
 //
 
 input[type="search"] {
-  -webkit-appearance: textfield; // 1
+  appearance: textfield; // 1
   box-sizing: content-box; //2
 }
 
@@ -366,7 +365,7 @@ input[type="search"] {
 
 input[type="search"]::-webkit-search-cancel-button,
 input[type="search"]::-webkit-search-decoration {
-  -webkit-appearance: none;
+  appearance: none;
 }
 
 //

--- a/src/less/pagination.less
+++ b/src/less/pagination.less
@@ -7,7 +7,7 @@
   padding-left: 0;
   margin-top: @line-height-computed;
   margin-bottom: 0;
-  .border-radius(@border-radius-base);
+  border-radius: @border-radius-base;
 
   > li {
     display: inline; // Remove list-style and block-level defaults
@@ -29,13 +29,15 @@
       > a,
       > span {
         margin-left: 0;
-        .border-left-radius(@border-radius-base);
+        border-top-left-radius: @border-radius-base;
+        border-bottom-left-radius: @border-radius-base;
       }
     }
     &:last-child {
       > a,
       > span {
-        .border-right-radius(@border-radius-base);
+        border-top-right-radius: @border-radius-base;
+        border-bottom-right-radius: @border-radius-base;
       }
     }
   }

--- a/src/less/pane.less
+++ b/src/less/pane.less
@@ -3,7 +3,7 @@ pane {
   max-height: 36px;
   overflow: hidden;
   display: block;
-  .transition(e(  'max-height .5s, margin-left .5s'));
+  transition: e('max-height .5s, margin-left .5s');
   background-color: @body-bg;
 
   &.pane-expanded {
@@ -32,7 +32,7 @@ pane {
     top: 91px;
     bottom: 0;
     background-color: #f2f2f2;
-    .box-shadow(inset -5px 0 3px 0 rgba(0,0,0,0.05));
+    box-shadow: inset -5px 0 3px 0 rgba(0,0,0,0.05);
     overflow: auto;
 
     ~ main {
@@ -60,7 +60,7 @@ pane {
   height: 36px;
   background-color: #d5d5d5;
   border-bottom: 1px solid @gray-200;
-  .box-shadow(inset -5px 0 3px 0 rgba(0,0,0,0.05));
+  box-shadow: inset -5px 0 3px 0 rgba(0,0,0,0.05);
   letter-spacing: 1px;
   font-size: @font-size-small;
 
@@ -71,7 +71,7 @@ pane {
     position: absolute;
     margin- top: 5px;
     margin-left: 10px;
-    .transition(e(  'margin-top .2s'));
+    transition: e('margin-top .2s');
     line-height: 26px;
     display: none;
 
@@ -108,7 +108,7 @@ pane {
   font-size: @font-size-small;
   color: @text-color-lighter;
   line-height: 26px;
-  .box-shadow(inset -5px 0 3px 0 rgba(0,0,0,0.05));
+  box-shadow: inset -5px 0 3px 0 rgba(0,0,0,0.05);
   border-bottom: 1px solid @border-color;
 }
 
@@ -119,7 +119,7 @@ pane {
   color: @text-color;
   display: inline-block;
   padding: 3px 5px;
-  .border-radius(@border-radius-small);
+  border-radius: @border-radius-small;
   line-height: 20px;
   font-size: @font-size-small;
 

--- a/src/less/picker.less
+++ b/src/less/picker.less
@@ -3,7 +3,7 @@
   height: 160px;
   border: solid 1px @gray-200;
   background-color: #fff;
-  .border-radius(4px);
+  border-radius: 4px;
   overflow: auto;
 
   .empty,
@@ -27,10 +27,6 @@
     margin: 0;
     font-weight: @font-weight-regular;
     position: relative;
-    -webkit-user-select: none;
-    -moz-user-select: none;
-    -ms-user-select: none;
-    -o-user-select: none;
     user-select: none;
 
     input {

--- a/src/less/pricingEstimate.less
+++ b/src/less/pricingEstimate.less
@@ -14,7 +14,7 @@
   #priceEstimate {
     background-color: #fff;
     padding: 5px 15px 15px;
-    .border-radius(@border-radius-base);
+    border-radius: @border-radius-base;
   }
 
   .cost-value {
@@ -79,7 +79,7 @@
 @media (min-width: @screen-sm) {
 
   #priceEstimateContainer {
-    .box-shadow(7px 0 7px -7px rgba(0, 0, 0, 0.2));
+    box-shadow: 7px 0 7px -7px rgba(0, 0, 0, 0.2);
 
 
     .cost-value {

--- a/src/less/progressBar.less
+++ b/src/less/progressBar.less
@@ -2,17 +2,17 @@ progress {
   width: 100%;
   display: block;
   /* Important Thing */
-  -webkit-appearance: none;
+  appearance: none;
   border: none;
   position: relative;
-  .border-radius(@progress-border-radius);
+  border-radius: @progress-border-radius;
   overflow: hidden;
   margin-bottom: 10px;
 
   &::-webkit-progress-bar {
     background: @progress-bg;
     border: solid 1px @border-color-dark;
-    .border-radius(@progress-border-radius);
+    border-radius: @progress-border-radius
   }
 
   &::-webkit-progress-value {
@@ -21,7 +21,9 @@ progress {
     left: 0;
     background-color: @progress-bar-success-bg;
     border: solid 1px darken(@progress-bar-success-bg, 10%);
-    .border-radius(@progress-border-radius 0 0 @progress-border-radius);
+    border-radius: @progress-border-radius;
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
   }
 
   &::-moz-progress-bar {
@@ -30,7 +32,9 @@ progress {
     left: 0;
     background-color: @progress-bar-success-bg;
     border: solid 1px darken(@progress-bar-success-bg, 10%);
-    .border-radius(@progress-border-radius 0 0 @progress-border-radius);
+    border-radius: @progress-border-radius;
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
   }
 
   &.info {

--- a/src/less/reset.less
+++ b/src/less/reset.less
@@ -60,7 +60,7 @@ button,
 html input[type="button"], // 1
 input[type="reset"],
 input[type="submit"] {
-  -webkit-appearance: button; // 2
+  appearance: button; // 2
   cursor: pointer; // 3
 }
 
@@ -125,7 +125,7 @@ input[type="number"]::-webkit-outer-spin-button {
 
 input[type="search"]::-webkit-search-cancel-button,
 input[type="search"]::-webkit-search-decoration {
-  -webkit-appearance: none;
+  appearance: none;
 }
 
 //

--- a/src/less/search.less
+++ b/src/less/search.less
@@ -11,7 +11,7 @@
     background-color: #fff;
     background-image: none;
     border: 1px solid #ccc;
-    .border-radius(@border-radius-base);
+    border-radius: @border-radius-base;
     transition: border-color ease-in-out 0.15s, box-shadow ease-in-out 0.15s;
     width: 100%;
 

--- a/src/less/site/misc.less
+++ b/src/less/site/misc.less
@@ -1,6 +1,6 @@
 .top-anchor {
   background-color: #000000;
-  .border-radius(4px);
+  border-radius: 4px;
   position: fixed;
   bottom: 2em;
   right: 1.5em;
@@ -61,7 +61,7 @@
 
 .primary-container {
   background-color: @body-bg;
-  .border-radius(@border-radius-large);
+  border-radius: @border-radius-large;
   padding: 20px;
 }
 
@@ -86,7 +86,7 @@
   border: 1px solid @border-color;
   background: #fff;
   padding: 40px 20px 20px;
-  .border-radius(@border-radius-large @border-radius-large 0 0);
+  border-radius: @border-radius-large @border-radius-large 0 0;
   margin-bottom: 25px;
   position: relative;
 

--- a/src/less/slideWell.less
+++ b/src/less/slideWell.less
@@ -7,8 +7,8 @@
   background: #f5f5f5;
   border-top: 1px solid @border-color;
   border-bottom: 1px solid @border-color;
-  .box-shadow(inset 0 0 5px 0 rgba(0,0,0,.1) );
-    padding: 10px 0;
+  box-shadow: inset 0 0 5px 0 rgba(0,0,0,.1);
+  padding: 10px 0;
 }
 
 @media (min-width: @screen-sm-min) {

--- a/src/less/slider.less
+++ b/src/less/slider.less
@@ -19,10 +19,10 @@ slider {
 }
 
 .slider-track {
-  background: #e3e3e3;
-  .gradient(#d7d7d7, rgba(227,227,211,.5));
+  background-color: #d7d7d7;
+  background-image: linear-gradient(to bottom, #d7d7d7, rgba(227,227,211,.5));
   border: solid 1px #bbb;
-  .border-radius(@border-radius-small);
+  border-radius: @border-radius-small;
   margin-right: 10px;
 
   .slider-min-bound-label,
@@ -124,7 +124,7 @@ slider {
       background-color: #fff;
       color: #555;
       border: solid 1px #bebebe;
-      .border-radius(@border-radius-small);
+      border-radius: @border-radius-small;
     }
   }
 
@@ -145,7 +145,7 @@ slider {
   height: 22px;
   background-color: #59b955;
   border: solid 1px #248e1b;
-  .border-radius(@border-radius-small);
+  border-radius: @border-radius-small;
 }
 
 .has-min-bound {
@@ -154,7 +154,7 @@ slider {
   }
 
   .slider-value-fill {
-    .border-radius(0);
+    border-radius: 0;
   }
 }
 

--- a/src/less/tag.less
+++ b/src/less/tag.less
@@ -8,7 +8,7 @@
   text-align: center;
   white-space: nowrap;
   vertical-align: baseline;
-  .border-radius(@border-radius-small);
+  border-radius: @border-radius-small;
 
   // Empty tags collapse automatically
   &:empty {

--- a/src/less/toggle.less
+++ b/src/less/toggle.less
@@ -3,9 +3,7 @@
   position: relative;
   width: 70px;
   height: 34px;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
+  user-select: none;
 
   &.disabled {
     cursor: not-allowed;
@@ -40,7 +38,7 @@
     overflow: hidden;
     cursor: pointer;
     border: 1px solid @border-color;
-    .border-radius(@border-radius-small);
+    border-radius: @border-radius-small;
     margin-bottom: 0;
   }
 
@@ -87,7 +85,7 @@
     top: 0;
     bottom: 0;
     right: 42px;
-    .border-radius(@border-radius-small);
+    border-radius: @border-radius-small;
     border: 1px solid @border-color;
     transition: all 0.3s ease-in 0s;
   }

--- a/src/less/tooltip.less
+++ b/src/less/tooltip.less
@@ -43,7 +43,7 @@
   color: @tooltip-color;
   text-align: center;
   background-color: @tooltip-bg;
-  .border-radius(@border-radius-base);
+  border-radius: @border-radius-base;
 }
 // Arrows
 .tooltip-arrow {

--- a/src/less/tree.less
+++ b/src/less/tree.less
@@ -68,8 +68,8 @@
 }
 
 .tree-item {
-  .transition(e('background-color .07s ease-in'));
-  .transition(e('color .07s ease-in'));
+  transition: e('background-color .07s ease-in');
+  transition: e('color .07s ease-in');
   background-color: #f9f9f9;
 
   &:hover {
@@ -92,7 +92,7 @@
 }
 
 .tree-item-status {
-  .transition(e('background-color .07s ease-in'));
+  transition: e('background-color .07s ease-in');
   background-color: @tree-list-status-default-bg;
   border-top: 1px solid lighten(@tree-list-status-default-bg, 5%);
   border-bottom: 1px solid darken(@tree-list-status-default-bg, 5%);
@@ -126,14 +126,14 @@
 
 .tree-in-pane {
   .tree-item {
-    .box-shadow(inset -5px 0 3px 0 rgba(0,0,0,0.05));
+    box-shadow: inset -5px 0 3px 0 rgba(0,0,0,0.05);
 
     &:hover {
       background-color: #fff;
     }
 
     &.selected {
-      .box-shadow(inset -5px 0 3px 0 rgba(0,0,0,0.2));
+      box-shadow: inset -5px 0 3px 0 rgba(0,0,0,0.2);
       background: #3a3a3a;
       color: #fff;
     }

--- a/src/less/upcomingEvents.less
+++ b/src/less/upcomingEvents.less
@@ -21,7 +21,7 @@
   .task-datetime {
     font-size: @font-size-small;
     margin: 0;
-    .transition(e('background-color .2s, color .2s'));
+    transition: e('background-color .2s, color .2s');
 
     &:hover {
       color: #000;
@@ -39,7 +39,7 @@
       }
 
       background-color: #e5e5e5;
-      .border-radius(5px);
+      border-radius: 5px;
       float: left;
       margin-right: 10px;
       padding: 5px 0 7px 0;

--- a/src/less/utilities.less
+++ b/src/less/utilities.less
@@ -5,8 +5,6 @@
 @import "utilities/type.less";
 @import "utilities/visibility.less";
 
-
-
 // For Affix plugin
 .affix {
   position: fixed;
@@ -20,65 +18,35 @@
 }
 
 .cyclops-spin {
-  -webkit-animation: cyclops-spin 2s infinite linear;
   animation: cyclops-spin 2s infinite linear;
-}
-
-@-webkit-keyframes cyclops-spin {
-  0% {
-    -webkit-transform: rotate(0deg);
-    transform: rotate(0deg);
-  }
-
-  100% {
-    -webkit-transform: rotate(359deg);
-    transform: rotate(359deg);
-  }
 }
 
 @keyframes cyclops-spin {
   0% {
-    -webkit-transform: rotate(0deg);
     transform: rotate(0deg);
   }
 
   100% {
-    -webkit-transform: rotate(359deg);
     transform: rotate(359deg);
   }
 }
 
 .cyclops-rotate-90 {
-  filter:progid:DXImageTransform.Microsoft.BasicImage(rotation=1);
-  -webkit-transform: rotate(90deg);
-  -ms-transform: rotate(90deg);
   transform: rotate(90deg);
 }
 
 .cyclops-rotate-180 {
-  filter:progid:DXImageTransform.Microsoft.BasicImage(rotation=2);
-  -webkit-transform: rotate(180deg);
-  -ms-transform: rotate(180deg);
   transform: rotate(180deg);
 }
 
 .cyclops-rotate-270 {
-  filter:progid:DXImageTransform.Microsoft.BasicImage(rotation=3);
-  -webkit-transform: rotate(270deg);
-  -ms-transform: rotate(270deg);
   transform: rotate(270deg);
 }
 
 .cyclops-flip-horizontal {
-  filter:progid:DXImageTransform.Microsoft.BasicImage(rotation=0, mirror=1);
-  -webkit-transform: scale(-1, 1);
-  -ms-transform: scale(-1, 1);
   transform: scale(-1, 1);
 }
 
 .cyclops-flip-vertical {
-  filter:progid:DXImageTransform.Microsoft.BasicImage(rotation=2, mirror=1);
-  -webkit-transform: scale(1, -1);
-  -ms-transform: scale(1, -1);
   transform: scale(1, -1);
 }

--- a/src/less/utilities/spacing.less
+++ b/src/less/utilities/spacing.less
@@ -6,7 +6,7 @@
 .v-center {
   position: relative;
   top: 50%;
-  .translate(0, -50%);
+  transform: translate(0, -50%);
 }
 
 .m-0 {


### PR DESCRIPTION
This brings in [Autoprefixer](https://github.com/postcss/autoprefixer) to the build pipeline by way of [gulp-autoprefixer](https://github.com/sindresorhus/gulp-autoprefixer). In adding support for Autoprefixer, we've removed a lot of the mixins that were providing the vendor prefixes in favor or using vanilla CSS.