### PR TITLE
Added .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+root = true
+
+[*]
+end_of_line = lf
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
For IDEs that support the [EditorConfig](http://editorconfig.org/) standard either natively or through plugins, it would be nice to include an .editorconfig file to help enforce the whitespace rules.