### PR TITLE
Gracefully Handle Less and CoffeeScript Compilation Errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,9 @@
     "gulp-util": "^3.0.6",
     "merge-stream": "^1.0.0",
     "nodemon": "^1.7.0",
+    "node-notifier": "^4.6.0",
     "phantomjs": "^2.1.3",
+    "stream-combiner2": "^1.1.1",
     "through2": "^2.0.1"
   }
 }


### PR DESCRIPTION
Adds error handling to Less and CoffeeScript compilation steps so that `gulp dev` doesn't die on you when you typo something.