### PR TITLE
ServerPickerServerViewModel isChecked option

### DIFF
--- a/src/scripts/models/ServerPickerViewModel.coffee
+++ b/src/scripts/models/ServerPickerViewModel.coffee
@@ -107,7 +107,7 @@ class ServerPickerServerViewModel
 
     @displayName = ko.asObservable if @rawServer.displayName? then @rawServer.displayName else @rawServer.name
 
-    @isChecked = ko.observable(false)
+    @isChecked = ko.observable(@rawServer.isChecked)
 
     @title = ko.computed () =>
       return options.getServerTitle(@rawServer)


### PR DESCRIPTION
The picker rebuilds the selected list using the base isChecked property of the ServerPickerServerViewModel during view construction. This makes it impossible to set selected servers after any async calls complete. This option allows us to set the checked option explicitly when setting up the content after view initialization.