### PR TITLE
Restore Disabled Class Name for Action Toolbar Items

### DIFF
--- a/src/less/actionToolbar.less
+++ b/src/less/actionToolbar.less
@@ -54,7 +54,7 @@
         a,
         button {
           background: transparent;
-            svg.cyclops-icon {		
+            svg.cyclops-icon {
               fill: @gray-200;
             }
         }
@@ -86,14 +86,14 @@
       outline:none;
 
 
-      &:active {		
+      &:active {
         background-color: @action-toolbar-active-bg;
-        svg.cyclops-icon {		
+        svg.cyclops-icon {
           fill: @black;
         }
       }
 
-      &:enabled { 
+      &:enabled {
         &:hover {
          background-color: @action-toolbar-hover-bg;
          svg.cyclops-icon {
@@ -102,6 +102,7 @@
         }
       }
 
+      &.disabled,
       &:disabled {
         color: #b9b9b9;
         cursor: @cursor-disabled;


### PR DESCRIPTION
This restores the ability to use the `disabled` class name on action toolbar items. This was removed in https://github.com/CenturyLinkCloud/Cyclops/commit/72fac7055a86f879896793f2bba4313c435609b3 and should resolve https://github.com/CenturyLinkCloud/Cyclops/issues/124.