### PR TITLE
Fixed outline button styles on anchor tags

### DIFF
--- a/src/less/buttons.less
+++ b/src/less/buttons.less
@@ -66,9 +66,7 @@ fieldset[disabled] {
 }
 
 .btn-outline {
-  &:enabled{
-    .button-variant(@btn-outline-color, @btn-outline-bg, @btn-outline-border);
-  }
+  .button-variant(@btn-outline-color, @btn-outline-bg, @btn-outline-border);
 
   &.btn-primary {
     .button-outline-variant(@btn-primary-bg);

--- a/www/views/partials/buttons/outline.html
+++ b/www/views/partials/buttons/outline.html
@@ -3,4 +3,5 @@
 <button type="button" class="btn btn-outline btn-primary">primary</button>
 <button type="button" class="btn btn-outline btn-warning">warning</button>
 <button type="button" class="btn btn-outline btn-danger">danger</button>
+<a role="button" class="btn btn-outline">as a link</a>
 </div>


### PR DESCRIPTION
I don't think this should break anything. I didn't see a specific :disabled rule. Should fix https://github.com/CenturyLinkCloud/Cyclops/issues/122.