### PR TITLE
Convert Layout Shell to Flexbox

### DIFF
--- a/src/less/accountSwitcher.less
+++ b/src/less/accountSwitcher.less
@@ -17,7 +17,7 @@
 
 account-switcher {
   display: block;
-  height: 40px;
+  height: @account-switcher-height;
   background-color: @account-switcher-bg;
   z-index: @zindex-account-switcher;
   position: relative;
@@ -51,7 +51,6 @@ account-switcher {
     background-color: @account-switcher-header-bg;
     color: @account-switcher-text;
     font-weight: @font-weight-regular;
-    height: 40px;
     padding: 5px 10px;
     z-index: @zindex-account-switcher;
     position: relative;

--- a/src/less/accountSwitcher.less
+++ b/src/less/accountSwitcher.less
@@ -18,6 +18,7 @@
 account-switcher {
   display: block;
   height: @account-switcher-height;
+  width: 100%;
   background-color: @account-switcher-bg;
   z-index: @zindex-account-switcher;
   position: relative;

--- a/src/less/base.less
+++ b/src/less/base.less
@@ -1,5 +1,29 @@
 body {
   background-color: @body-bg;
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+}
+
+body > .main-wrapper,
+body > main {
+  min-height: calc(100vh - @account-switcher-height - @navbar-height);
+  flex-grow: 1;
+  width: 0;
+}
+
+body > .main-wrapper {
+  display: flex;
+  flex-direction: column;
+
+  @media (min-width: @screen-sm-min) {
+    flex-direction: row;
+
+    main {
+      flex-grow: 1;
+      width: 0;
+    }
+  }
 }
 
 hr {

--- a/src/less/mainNav.less
+++ b/src/less/mainNav.less
@@ -11,6 +11,8 @@ main-nav {
   background: @main-nav-bg;
   color: @main-nav-text;
   flex-shrink: 0;
+  box-shadow: 7px 0 7px -7px rgba(0,0,0,.2); //right shadow
+  border-right: 1px solid @gray-100;
 
   a {
     display: inline-block;
@@ -29,15 +31,14 @@ main-nav {
 }
 
 .main-nav-menu {
-  height: 100vh;
+  max-height: 100%;
   overflow-x: hidden;
   overflow-y: auto;
   position: sticky;
   top: 0;
   z-index: @zindex-main-nav + 1;
   background: @main-nav-bg;
-  box-shadow: 7px 0 7px -7px rgba(0,0,0,.2); //right shadow
-  border-right: 1px solid @gray-100;
+  -ms-overflow-style: -ms-autohiding-scrollbar;
 
   .cyclops-icon {
     width: 20px;

--- a/src/less/mainNav.less
+++ b/src/less/mainNav.less
@@ -1,29 +1,16 @@
+//
+// Main Navigation
+//
+// The main navigation area (i.e. <main-nav>) is displayed
+// persistently on the left side of the window and allows the user
+// to switch between various sections and satellite applications.
+//
 main-nav {
-  position: fixed;
-  top: 91px;
-  bottom: 0;
   width: @main-nav-width-sm;
-  overflow: visible;
   z-index: @zindex-main-nav;
   background: @main-nav-bg;
-  transition: width .5s;
   color: @main-nav-text;
-
-  // Prevent a BUFOC
-  &:before {
-    content: ' ';
-    position: fixed;
-    top: 0;
-    bottom: 0;
-    width: @main-nav-width-sm;
-    background: @main-nav-bg;
-    transition: width .5s;
-    z-index: -1;
-  }
-
-  &.loaded:before {
-    display: none;
-  }
+  flex-shrink: 0;
 
   a {
     display: inline-block;
@@ -32,16 +19,21 @@ main-nav {
     color: @main-nav-link-text;
   }
 
-  ~ pane,
-  ~ main {
-    margin-left: @main-nav-width-sm;
+  @media (min-width: @screen-sm-min) {
+    width: @main-nav-width-md;
+  }
+
+  @media (min-width: @screen-xl-min) {
+    width: @main-nav-width-lg;
   }
 }
 
 .main-nav-menu {
-  height: 100%;
-  overflow: hidden;
-  position: relative;
+  height: 100vh;
+  overflow-x: hidden;
+  overflow-y: auto;
+  position: sticky;
+  top: 0;
   z-index: @zindex-main-nav + 1;
   background: @main-nav-bg;
   box-shadow: 7px 0 7px -7px rgba(0,0,0,.2); //right shadow
@@ -70,14 +62,13 @@ main-nav {
     letter-spacing: 0;
     text-align: center;
 
-    &:focus,
-    &:hover {
+    &:focus, &:hover {
       background-color: @main-nav-hover-bg;
       color: @main-nav-link-text-hover;
       outline: none;
 
       .cyclops-icon use {
-        fill: @main-nav-link-text-hover;
+        fill: currentColor;
       }
     }
 
@@ -88,36 +79,9 @@ main-nav {
       transform: scale(.985,.985);
 
       .cyclops-icon use {
-        fill: @main-nav-link-text-active;
+        fill: currentColor;
       }
     }
-  }
-
-  .scroll-up,
-  .scroll-down {
-    display: none;
-    position: absolute;
-    z-index: @zindex-main-nav + 2;
-    width: 100%;
-    transition: none;
-    padding-left: 0;
-    padding-right: 0;
-
-    svg {
-      margin: 0 0 0 1px;
-    }
-  }
-
-  .scroll-up {
-    background: linear-gradient(to top, rgba(255,255,255,0) 0%, rgba(255,255,255,.5) 20%, rgba(255,255,255,1) 100%);
-    border-bottom: 0px;
-    top: 0;
-  }
-
-  .scroll-down {
-    bottom: 0;
-    background: linear-gradient(to bottom, rgba(255,255,255,0) 0%, rgba(255,255,255,.5) 20%, rgba(255,255,255,1) 100%);
-    border-top: 0px;
   }
 }
 
@@ -171,7 +135,7 @@ main-nav {
         color: @main-nav-link-text-active;
 
         .cyclops-icon use {
-          fill: @main-nav-link-text-active;
+          fill: currentColor;
         }
       }
     }
@@ -314,33 +278,8 @@ main-nav {
 }
 
 @media (min-width: @screen-sm-min) {
-  main-nav {
-    width: @main-nav-width-md;
-    // Prevent a BUFOC
-    &:before {
-      width: @main-nav-width-md;
-    }
-
-    ~ pane,
-    ~ main {
-      margin-left: @main-nav-width-md;
-    }
-
-    ~ main {
-      .container {
-        width: @container-sm - @main-nav-width-md;
-      }
-    }
-
-    ~ pane ~ main {
-      margin-left: @main-nav-width-md + @pane-width;
-
-    }
-  }
-
   .main-nav-menu {
-    a.btn,
-    button.btn {
+    .btn {
       padding: 10px;
       letter-spacing: 0;
 
@@ -372,58 +311,9 @@ main-nav {
   }
 }
 
-@media (min-width: @screen-md-min) {
-  main-nav {
-    ~ main {
-      .container {
-        width: @container-md - @main-nav-width-md;
-      }
-    }
-  }
-}
-
-@media (min-width: @screen-lg-min) {
-  main-nav {
-    ~ main {
-      .container {
-        width: @container-lg - @main-nav-width-md;
-      }
-    }
-  }
-}
-
 @media (min-width: @screen-xl-min) {
-  main-nav {
-    width: @main-nav-width-lg;
-    // Prevent a BUFOC
-    &:before {
-      width: @main-nav-width-lg;
-    }
-
-    &:before {
-      width: @main-nav-width-lg;
-    }
-
-    ~ pane,
-    ~ main {
-      margin-left: @main-nav-width-lg;
-    }
-
-    ~ main {
-      .container {
-        width: @container-xl - @main-nav-width-lg;
-      }
-    }
-
-    ~ pane ~ main {
-      margin-left: @main-nav-width-lg + @pane-width;
-    }
-
-  }
-
   .main-nav-menu {
-    a.btn,
-    button.btn {
+    .btn {
       text-align: left;
       font-size: @font-size-regular;
       padding: 10px 10px 10px 15px;
@@ -432,11 +322,6 @@ main-nav {
         display: inline;
         margin-right: 7px;
         margin-bottom: 0;
-      }
-
-      &.scroll-up,
-      &.scroll-down {
-        text-align: center;
       }
     }
   }

--- a/src/less/navbar.less
+++ b/src/less/navbar.less
@@ -12,6 +12,7 @@
   min-height: @navbar-height; // Ensure a navbar always shows (e.g., without a .navbar-brand in collapsed mode)
   margin-bottom: @navbar-margin-bottom;
   border: 1px solid transparent;
+  width: 100%;
 
   // Prevent floats from breaking the navbar
   &:extend(.clearfix all);

--- a/src/less/pane.less
+++ b/src/less/pane.less
@@ -1,14 +1,18 @@
 pane {
-  position: static;
-  max-height: 36px;
-  overflow: hidden;
+  position: relative;
   display: block;
   transition: e('max-height .5s, margin-left .5s');
   background-color: #fff;
 
+  .pane-content {
+    max-height: 36px;
+    overflow: hidden;
+  }
+
   &.pane-expanded {
-    max-height: none;
-    overflow-y: auto;
+    .pane-content {
+      max-height: none;
+    }
 
     .pane-actions {
       display: block;
@@ -24,34 +28,18 @@ pane {
       display: block;
     }
   }
+
   @media (min-width: @screen-sm-min) {
-    max-height: none;
     width: @pane-width;
-    position: fixed;
-    height: auto;
-    top: 91px;
-    bottom: 0;
     background-color: #f2f2f2;
     box-shadow: inset -5px 0 3px 0 rgba(0,0,0,0.05);
-    overflow: auto;
 
-    ~ main {
-      margin-left: @pane-width;
-
-      .container {
-        width: 100%;
-      }
-    }
-  }
-  @media (min-width: @screen-md-min) {
-    ~ main .container {
-      width: @container-md - @pane-width;
-      margin-left: 0;
-    }
-  }
-  @media (min-width: @screen-lg-min) {
-    ~ main .container {
-      width: @container-lg - @pane-width;
+    .pane-content {
+      max-height: none;
+      position: sticky;
+      top: 0;
+      overflow-x: hidden;
+      overflow-y: auto;
     }
   }
 }
@@ -137,6 +125,7 @@ pane {
 
 .pane-toggle {
   float: right;
+
   @media (min-width: @screen-sm-min) {
     display: none;
   }
@@ -144,6 +133,7 @@ pane {
 
 .pane-actions {
   display: none;
+
   @media (min-width: @screen-sm-min) {
     display: block;
   }

--- a/src/less/variables.less
+++ b/src/less/variables.less
@@ -233,6 +233,7 @@
 
 //== Account Switcher
 //
+@account-switcher-height:             40px;
 @account-switcher-header-bg:          @black;
 @account-switcher-text:               @gray-200;
 @account-switcher-border-color:       @black;

--- a/src/scripts/models/mainNavViewModel.coffee
+++ b/src/scripts/models/mainNavViewModel.coffee
@@ -64,8 +64,6 @@ class MainNavMenuItem
     ko.computed () =>
       @flyoutItems @rawFlayoutItems().map (f) -> new MainNavFlyoutItem(f)
 
-
-
     # Items can either have and location to navigate to or items but not both
     if ko.unwrap(options.href)? and ko.unwrap(options.items)?
       throw "The Menu Item with name '#{@name()}' has defined both a href and
@@ -85,77 +83,21 @@ class MainNavViewModel
       error: false
     }, options
 
-    # make main-nav sticky
     $mainNav = $(element)
-    $window = $(window)
-    $accountSwitcher = $('account-switcher')
-    $navbar = $('brand-bar, nav.navbar')
-
-    calculateMainNavPosition = () =>
-      originalTopPosition = 0
-      originalTopPosition += 40 if $accountSwitcher.length > 0
-      originalTopPosition += 51 if $navbar.length > 0
-      newTopPosition = originalTopPosition - $window.scrollTop()
-      if newTopPosition < 0
-        newTopPosition = 0
-      $mainNav.css('top': newTopPosition)
-    calculateMainNavPosition()
-    $window.on 'scroll', calculateMainNavPosition
-    $window.on 'resize', calculateMainNavPosition
-
-    # Set up Scrolling of many menu Items
-    @updateMainMenuScrollIcons = () ->
-      $items =  $mainNav.find '.main-nav-menu-items'
-      $up = $mainNav.find('.scroll-up')
-      $down = $mainNav.find('.scroll-down')
-
-      if $items.scrollTop() + $items.innerHeight() >= $items[0].scrollHeight
-        if $down.is ':visible'
-          $down.stop().fadeOut()
-      else
-        if $down.is ':hidden'
-          $down.stop().fadeIn()
-
-      if $items.scrollTop() == 0
-        $mainNav.find('.scroll-up').fadeOut()
-      else
-        $mainNav.find('.scroll-up').fadeIn()
-
-
-    $mainNav.find(".main-nav-menu-items").on 'scroll', @updateMainMenuScrollIcons
-    $window.on 'resize', @updateMainMenuScrollIcons
-
-
-
-    @scrollDownHandler = (data, event) ->
-      $items = $mainNav.find('.main-nav-menu-items')
-      $items.scrollTop $items.scrollTop() + 26
-
-    @scrollUpHandler = (data, event) ->
-      $items = $mainNav.find('.main-nav-menu-items')
-      $items.scrollTop($items.scrollTop() - 26)
 
     # states
     @isLoading = ko.asObservable(options.loading)
     @hasErrored = ko.asObservable(options.error)
 
-
-
     # create menus
     @rawMenus = ko.asObservable(options.menus)
     renderTimeout = null
     @menus = ko.pureComputed () =>
-      result = @rawMenus().reduce (menus, menu) =>
+      @rawMenus().reduce (menus, menu) =>
         if menu.href? or (menu.items and ko.unwrap(menu.items).length > 0)
           menus.push new MainNavMenuItem(menu)
-        return menus
+        menus
       , []
-      # we are using a timeout here for performance reason so that its not called
-      # 100s of times becuase of the recreation of the entire array.
-      if renderTimeout
-        window.clearTimeout renderTimeout
-      renderTimeout = window.setTimeout @updateMainMenuScrollIcons, 500
-      return result
 
     # selected item
     @SelectedItemId = ko.asObservable(options.selectedItemId)
@@ -197,6 +139,5 @@ class MainNavViewModel
       closeTimer = window.setTimeout () =>
         @menus().forEach (m) -> m.isFlyoutOpen false
       , 1000
-
 
     $mainNav.addClass 'loaded'

--- a/src/scripts/models/paneViewModel.coffee
+++ b/src/scripts/models/paneViewModel.coffee
@@ -144,5 +144,3 @@ class PaneViewModel
     # Mobile View
     @togglePane = () ->
       $(element).toggleClass 'pane-expanded'
-
-    $(element).affix()

--- a/src/templates/mainNav.tmpl.html
+++ b/src/templates/mainNav.tmpl.html
@@ -1,6 +1,5 @@
 <script type="text/html" id="cyclops.mainNav">
   <div class="main-nav-menu">
-    <button class="scroll-up btn btn-link hide" data-bind="click: scrollUpHandler"><svg class="cyclops-icon"><use xlink:href='#icon-chevron-up'></svg></button>
     <!-- ko empty: menus -->
     <!-- ko if: hasErrored -->
     <div class="main-nav-error" title="unable to fetch">
@@ -18,7 +17,6 @@
     <ol class="main-nav-menu-items" data-bind="foreach: menus">
       <li data-bind="css: {'open': isFlyoutOpen, 'selected': isSelected}, template: templateName, title: name"></li>
     </ol>
-    <button class="scroll-down btn btn-link" data-bind="click: scrollDownHandler"><svg class="cyclops-icon"><use xlink:href='#icon-chevron-down'></svg></button>
   </div>
   <!-- ko template:{name: 'cyclops.mainNav.menuItem.flyout', foreach: menus} -->
   <!-- /ko -->

--- a/src/templates/pane.tmpl.html
+++ b/src/templates/pane.tmpl.html
@@ -1,6 +1,8 @@
 <script type="text/html" id="cyclops.pane">
-  <!-- ko template: headerTemplateName --><!-- /ko -->
-  <!-- ko template: bodyTemplateName --><!-- /ko -->
+  <div class="pane-content">
+    <!-- ko template: headerTemplateName --><!-- /ko -->
+    <!-- ko template: bodyTemplateName --><!-- /ko -->
+  </div>
 </script>
 
 <script type=text/html id="cyclops.paneForeach">

--- a/www/views/starterPages/pane.html
+++ b/www/views/starterPages/pane.html
@@ -1,160 +1,155 @@
 {{!< ../layouts/starter-page.html}}
 
-<pane params="{items: items, selectedItemId: selectedItemId, loading: loading }"></pane>
-
 <style>
-
   @media (min-width: 992px) {
     .navbar-local--pillbar {
       position: sticky;
       top: 0;
     }
   }
-
 </style>
 
-<main>
-  {{> navigation/examples/nav-local-persistent }}
-  <div class="container-fluid">
-    <div class="row">
-      <div class="col-sm-12">
-        <div class="content-header">
-          <ol class="breadcrumb hidden-md-up">
-            <li><a href="index.html">UC1 - US West (Santa Clara)</a></li>
-          </ol>
-          <h1>QA1WEBSERVER02</h1>
-          <p class="lead">New Navigation Sample</p>
-        </div>
-        {{> components/examples/billing-summary-3 }}
-      </div>
-    </div>
-  </div>
+<div class="main-wrapper">
+  <pane params="{items: items, selectedItemId: selectedItemId, loading: loading }"></pane>
+  <main>
 
-  {{> components/examples/action-toolbar-right }}
-  <div class="primary">
+    {{> navigation/examples/nav-local-persistent }}
+
     <div class="container-fluid">
       <div class="row">
         <div class="col-sm-12">
-          {{> list-view/toolbar }}
-          {{> list-view/basic }}
+          <div class="content-header">
+            <ol class="breadcrumb hidden-md-up">
+              <li><a href="index.html">UC1 - US West (Santa Clara)</a></li>
+            </ol>
+            <h1>QA1WEBSERVER02</h1>
+            <p class="lead">New Navigation Sample</p>
+          </div>
+          {{> components/examples/billing-summary-3 }}
         </div>
       </div>
     </div>
-  </div>
 
+    {{> components/examples/action-toolbar-right }}
 
-  <div class="container-fluid">
-    {{> components/examples/activity-history }}
-  </div>
+    <div class="primary">
+      <div class="container-fluid">
+        <div class="row">
+          <div class="col-sm-12">
+            {{> list-view/toolbar }}
+            {{> list-view/basic }}
+          </div>
+        </div>
+      </div>
+    </div>
 
-</main>
+    <div class="container-fluid">
+      {{> components/examples/activity-history }}
+    </div>
 
+  </main>
+</div>
 
 {{#contentFor "scripts"}}
-
-<script>
-  $(function(){
-    var ViewModel = function(){
-      var self = this;
-      self.loading = ko.observable(true);
-      self.items = [
-        { id: "qa1", name: "QA1 - US West (Bellevue)", href: "#/qa1", items: ko.observableArray([]), icons: ko.observableArray(["#icon-circle-o"]) },
-        { id: "qa3", name: "[Private] QA3 - US West (Spokane)", href: "#/qa3", items: ko.observableArray([]), icons: ko.observableArray(["#icon-circle-o"]) }
-      ]
-      self.selectedItemId = ko.observable("QA1WEBSERVER02")
-      return self;
-    };
-
-
-    var model = new ViewModel();
-
-    // QA1 loading
-    setTimeout(function(){
-      var qa1 = model.items[0]
-      qa1.items.push({
-        href: "#/qa1/123",
-        id: "123",
-        name: "Default Group",
-        icons: ['#icon-folder'],
-        items: [
-          {
-            href: "#/qa1/123/QA1DEVSERVER01",
-            id: "QA1DEVSERVER01",
-            icons: ["#icon-play"],
-            name: "QA1DEVSERVER01"
-          },
-          {
-            href: "#/qa1/123/QA1DEVSERVER02",
-            id: "QA1DEVSERVER02",
-            icons: ["#icon-stop"],
-            name: "QA1DEVSERVER01"
-          }
+  <script>
+    $(function(){
+      var ViewModel = function(){
+        var self = this;
+        self.loading = ko.observable(true);
+        self.items = [
+          { id: "qa1", name: "QA1 - US West (Bellevue)", href: "#/qa1", items: ko.observableArray([]), icons: ko.observableArray(["#icon-circle-o"]) },
+          { id: "qa3", name: "[Private] QA3 - US West (Spokane)", href: "#/qa3", items: ko.observableArray([]), icons: ko.observableArray(["#icon-circle-o"]) }
         ]
-      });
-      qa1.items.push({
-        href: "#/qa1/456",
-        id: "456",
-        name: "Web Servers",
-        icons: ['#icon-folder'],
-        items: [
-          {
-            href: "#/qa1/123/QA1WEBSERVER01",
-            id: "QA1WEBSERVER01",
-            icons: ["#icon-bare-metal", "#icon-play"],
-            name: "QA1WEBSERVER01"
-          },
-          {
-            href: "#/qa1/123/QA1WEBSERVER02",
-            id: "QA1WEBSERVER02",
-            icons: ["#icon-bare-metal", "#icon-play"],
-            name: "QA1WEBSERVER02"
-          }
-          ,
-          {
-            href: "#/qa1/123/QA1WEBSERVER03",
-            id: "QA1WEBSERVER03",
-            icons: ["#icon-play"],
-            name: "QA1WEBSERVER03",
-            statusClass: "warning"
-          }
-        ]
-      });
-      qa1.items.push({
-        href: "#/qa1/789",
-        id: "789",
-        name: "Database Servers",
-        icons: ['#icon-folder']
-      });
-      qa1.icons(["#icon-dot-circle-o"]);
-      if(model.loading())
-        model.loading(false);
-    }, Math.floor(Math.random() * 5000) + 1 );
+        self.selectedItemId = ko.observable("QA1WEBSERVER02")
+        return self;
+      };
 
-    // QA2 loading
-    setTimeout(function(){
-      var qa2 = model.items[1]
-      qa2.items.push({
-        href: "#/qa2/999",
-        id: "999",
-        name: "Default Group",
-        icons: ['#icon-folder']
-      });
-      qa2.items.push({
-        href: "#/qa2/111",
-        id: "111",
-        name: "Web Servers",
-        icons: ['#icon-folder']
-      });
-      qa2.icons(["#icon-dot-circle-o"]);
-      if(model.loading())
-        model.loading(false);
-    }, Math.floor(Math.random() * 5000) + 1 );
+      var model = new ViewModel();
 
+      // QA1 loading
+      setTimeout(function(){
+        var qa1 = model.items[0]
+        qa1.items.push({
+          href: "#/qa1/123",
+          id: "123",
+          name: "Default Group",
+          icons: ['#icon-folder'],
+          items: [
+            {
+              href: "#/qa1/123/QA1DEVSERVER01",
+              id: "QA1DEVSERVER01",
+              icons: ["#icon-play"],
+              name: "QA1DEVSERVER01"
+            },
+            {
+              href: "#/qa1/123/QA1DEVSERVER02",
+              id: "QA1DEVSERVER02",
+              icons: ["#icon-stop"],
+              name: "QA1DEVSERVER01"
+            }
+          ]
+        });
+        qa1.items.push({
+          href: "#/qa1/456",
+          id: "456",
+          name: "Web Servers",
+          icons: ['#icon-folder'],
+          items: [
+            {
+              href: "#/qa1/123/QA1WEBSERVER01",
+              id: "QA1WEBSERVER01",
+              icons: ["#icon-bare-metal", "#icon-play"],
+              name: "QA1WEBSERVER01"
+            },
+            {
+              href: "#/qa1/123/QA1WEBSERVER02",
+              id: "QA1WEBSERVER02",
+              icons: ["#icon-bare-metal", "#icon-play"],
+              name: "QA1WEBSERVER02"
+            }
+            ,
+            {
+              href: "#/qa1/123/QA1WEBSERVER03",
+              id: "QA1WEBSERVER03",
+              icons: ["#icon-play"],
+              name: "QA1WEBSERVER03",
+              statusClass: "warning"
+            }
+          ]
+        });
+        qa1.items.push({
+          href: "#/qa1/789",
+          id: "789",
+          name: "Database Servers",
+          icons: ['#icon-folder']
+        });
+        qa1.icons(["#icon-dot-circle-o"]);
+        if(model.loading())
+          model.loading(false);
+      }, Math.floor(Math.random() * 5000) + 1 );
 
+      // QA2 loading
+      setTimeout(function(){
+        var qa2 = model.items[1]
+        qa2.items.push({
+          href: "#/qa2/999",
+          id: "999",
+          name: "Default Group",
+          icons: ['#icon-folder']
+        });
+        qa2.items.push({
+          href: "#/qa2/111",
+          id: "111",
+          name: "Web Servers",
+          icons: ['#icon-folder']
+        });
+        qa2.icons(["#icon-dot-circle-o"]);
+        if(model.loading())
+          model.loading(false);
+      }, Math.floor(Math.random() * 5000) + 1 );
 
-
-    ko.applyBindings(model, $("pane")[0]);
-    ko.applyBindings({}, $(".action-area")[0]);
-  });
-</script>
+      ko.applyBindings(model, $("pane")[0]);
+      ko.applyBindings({}, $(".action-area")[0]);
+    });
+  </script>
 {{/contentFor}}

--- a/www/views/starterPages/price-estimate-create.html
+++ b/www/views/starterPages/price-estimate-create.html
@@ -4,6 +4,7 @@
 
   @media (min-width: 768px) {
     #priceEstimateContainer {
+      position: -webkit-sticky;
       position: sticky;
       top: 0;
     }


### PR DESCRIPTION
Changes the shell (i.e. `<main-nav>`, `<account-switcher>`, `<pane>`, ...) layout to use Flexbox. This started out as an attempt to use Flexbox without requiring any markup changes, but unfortunately, it is not backwards compatible as a new wrapper element is required for correct responsive/mobile support.

**Changes**

* Favored using `position: sticky` on `<main-nav>` and `<pane>` contents in place of scroll observers.
* Overflow scrolling in the `<main-nav>` is now handled natively with `overflow` in place of buttons to scroll up and down with JavaScript.
* Extracted the height of the account switcher into a variable for easier reference/calculation.
* The body is now a flex container.
* Added a new "main" wrapper (`.main-wapper`) that allows us to properly layout panes in mobile or responsive modes.
* The pane template now has an additional wrapper for pane content to allow `position: sticky` to work correctly.

**Notes**

* We might want to require an outer wrapper as to not make the body itself a flex container.
* The addition of the main wrapper is a change that requires consumers of Cyclops to implement.