### PR TITLE
Fix Password Strength Logic Error

### DIFF
--- a/specs/helpers/calculatePasswordStrength.spec.coffee
+++ b/specs/helpers/calculatePasswordStrength.spec.coffee
@@ -11,6 +11,9 @@ describe 'helpers: calculatePasswordStrength', ->
   it 'returns 2 for 8 character passwords with 3 char types', ->
     expect(helpers.calculatePasswordStrength('aA!AaAaA')).toEqual(2)
     return
+  it 'returns 2 for 8 character passwords with 4 char types', ->
+    expect(helpers.calculatePasswordStrength('aA!AaAa1')).toEqual(2)
+    return
   it 'returns 3 for 9 character passwords with 3 char types', ->
     expect(helpers.calculatePasswordStrength('aA!AaAaAa')).toEqual(3)
     return

--- a/src/scripts/helpers/calculatePasswordStrength.coffee
+++ b/src/scripts/helpers/calculatePasswordStrength.coffee
@@ -17,7 +17,7 @@ helpers.calculatePasswordStrength = (password) ->
     strength = 0
   else if charTypes < 3
     strength = 1
-  else if password.length == 8 and charTypes == 3
+  else if password.length == 8 and charTypes >= 3
     strength = 2
   else if password.length >= 9 and charTypes == 3
     strength = 3


### PR DESCRIPTION
Fixes a logic error (reported in #154) wherein passwords with a length of 8 characters that have 4 character types are marked as 0 instead of 2 (like the same passwords with only 3 character types).