### PR TITLE
Fix Misspelling in Password Strength Helper

### DIFF
--- a/src/scripts/validators/passwordStrength.coffee
+++ b/src/scripts/validators/passwordStrength.coffee
@@ -3,12 +3,12 @@ if libraries.knockoutValidation
     validator: (val, options) ->
       options = $.extend({
         requiredStrength: 3
-        dissallowedCharacters: []
+        disallowedCharacters: []
       }, options)
       if !val
         return true
       strength = helpers.calculatePasswordStrength(val)
-      badCharacters = helpers.containsAny(val, options.dissallowedCharacters)
+      badCharacters = helpers.containsAny(val, (options.dissallowedCharacters || options.disallowedCharacters))
       if badCharacters.length > 0
         many = badCharacters.length > 1
         @message = 'The character' + (if many then 's' else '') + ' \'' + badCharacters.join('\', \'') + '\' ' + (if many then 'are' else 'is') + ' not allowed.'

--- a/www/views/forms.html
+++ b/www/views/forms.html
@@ -64,7 +64,7 @@ $(function(){
     var self = this;
     self.password = ko.observable().extend({
         required: { params: true, message: "A password is required." },
-        passwordStrength: { requiredStrength: 4, dissallowedCharacters: "[}" }
+        passwordStrength: { requiredStrength: 4, disallowedCharacters: "[}" }
     });
     self.errors = ko.validation.group([self.password])
     self.submit = function() {

--- a/www/views/partials/forms/validation.html
+++ b/www/views/partials/forms/validation.html
@@ -242,7 +242,7 @@ self.submit = function() {
     <code class="javascript">
 self.password = ko.observable().extend({
     required: { params: true, message: "A password is required." },
-    passwordStrength: { requiredStrength: 4, dissallowedCharacters: "[}" }
+    passwordStrength: { requiredStrength: 4, disallowedCharacters: "[}" }
 });
 self.errors = ko.validation.group([self.password])
 self.submit = function() {

--- a/www/views/validators.html
+++ b/www/views/validators.html
@@ -171,7 +171,7 @@ self.password = ko.observableArray().extend({
 <pre>
   <code class="javascript">
 self.password = ko.observable().extend({
-    passwordStrength: { requiredStrength: 4, dissallowedCharacters: &quot;[}&quot; }
+    passwordStrength: { requiredStrength: 4, disallowedCharacters: &quot;[}&quot; }
 });
   </code>
 </pre>
@@ -194,7 +194,7 @@ self.password = ko.observable().extend({
       <td>calculated based on character types and length</td>
     </tr>
     <tr>
-      <td>dissallowedCharacters</td>
+      <td>disallowedCharacters</td>
       <td>String</td>
       <td>none</td>
       <td>a string containing disallowed characters</td>


### PR DESCRIPTION
The option `disallowedCharacters` was misspelled as `dissallowedCharacters`. This adds support for the correct spelling while continuing to allow the misspelling to be used.