### PR TITLE
Fix Hover Styles on Disabled Icon Buttons

### DIFF
--- a/src/less/buttons.less
+++ b/src/less/buttons.less
@@ -296,6 +296,15 @@ fieldset.disabled {
     border-color: transparent;
     background: none;
   }
+
+  &:disabled,
+  &.disabled {
+    &:hover {
+      box-shadow: none;
+      border-color: transparent;
+      background: none;
+    }
+  }
 }
 
 // Block button

--- a/src/less/mixins.less
+++ b/src/less/mixins.less
@@ -362,6 +362,15 @@
         fill: @active-background;
       }
     }
+
+    &.disabled,
+    &:disabled {
+      &:hover {
+        .cyclops-icon {
+          fill: @background;
+        }
+      }
+    }
   }
 
   .cyclops-icon {


### PR DESCRIPTION
Removes the hover background and the highlight state on icon buttons that are disabled. Fixes #143.