### PR TITLE
Fix Pie/Guage/Donut Charts

### DIFF
--- a/src/scripts/widgets/chart.coffee
+++ b/src/scripts/widgets/chart.coffee
@@ -15,13 +15,14 @@ if libraries.chartist
       getErrorMessageHtml: () -> return 'Unable to fetch data.'
       chartOptions: {
         fullWidth: true,
-        chartPadding: {
-          right: 20
-        },
         lineSmooth: false
       }
       responsiveOptions: {}
     }, options
+
+    if options.type == 'Line' or options.type == 'Bar'
+      unless options.chartOptions.chartPadding
+        options.chartOptions.chartPadding = { right: 20 }
 
     if(options.type == 'Donut')
       options.type = 'Pie'


### PR DESCRIPTION
Pie, Gauge and Donut charts have all been broken unless `chartOptions` were specified that removed a default that was added for line charts in https://github.com/CenturyLinkCloud/Cyclops/commit/b2fdd67b681671eba16b6a9228d040caeade4f03. This should fix it and retain the default options for line and bar charts.

Fixes #153.