### PR TITLE
Fix Local Date and Time Display in Date and Time Picker Component

### DIFF
--- a/src/scripts/models/DateTimePickerViewModel.coffee
+++ b/src/scripts/models/DateTimePickerViewModel.coffee
@@ -84,7 +84,7 @@ class DateTimePickerViewModel
       # make sure we set the UTC Offset back to what the user selected
       @sourceDateTime().utcOffset @zoneValue(), true
       @sourceDateTime().date newMoment.date()
-      @sourceDateTime().month newMoment.utc().month()
+      @sourceDateTime().month newMoment.month()
       @sourceDateTime().year newMoment.year()
       @sourceDateTime.notifySubscribers()
       return


### PR DESCRIPTION
When close to the end or beginning of a month, an error existed in which the preview date would not be calculated and displayed correctly. This fixes #152.