### PR TITLE
[CAM-11344] Fix Cyclops Inverse menu dropdown colors to match Chi

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cyclops",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "cyclops: The UI/UX Pattern Guide",
   "scripts": {
     "test": "gulp test",

--- a/src/less/dropdown.less
+++ b/src/less/dropdown.less
@@ -52,7 +52,7 @@ div.dropdown {
 
     > li a:hover,
     > li button:hover {
-      background: @gray-50;
+      background: @gray-75;
     }
 
     // Links, buttons and text within the dropdown menu

--- a/src/less/navbar.less
+++ b/src/less/navbar.less
@@ -573,6 +573,10 @@
     }
   }
 
+  #navbar-services:before {
+    background-color: @gray-400;
+  }
+
   .navbar-service {
     border-left: 1px solid lighten(@navbar-inverse-bg, 5%);
     color: @navbar-inverse-brand-color;
@@ -583,35 +587,6 @@
     }
   }
 
-  .navbar-account {
-
-    a:hover,
-    button:hover {
-      .cyclops-icon {
-        fill: #fff;
-      }
-    }
-
-
-    li.open .cyclops-icon use {
-      fill: #fff;
-    }
-
-    @media (min-width: @grid-float-breakpoint) {
-      border-left: 1px solid darken(@navbar-inverse-bg, 5%);
-      border-right: 1px solid lighten(@navbar-inverse-bg, 5%);
-
-      > li {
-        border-left: 1px solid lighten(@navbar-inverse-bg, 5%);
-        border-right: 1px solid darken(@navbar-inverse-bg, 5%);
-      }
-    }
-  }
-
-  .dropdown-menu {
-    background-color: @navbar-inverse-bg;
-  }
-
   svg {
     fill: @navbar-inverse-link-color;
   }
@@ -620,7 +595,6 @@
     color: @navbar-inverse-text;
   }
 
-  .dropdown-menu,
   .navbar-nav {
     > li > button,
     > li > a {
@@ -657,22 +631,6 @@
     }
   }
 
-  .dropdown-menu {
-
-    border: 1px solid darken(@navbar-inverse-bg, 5%);
-
-    li {
-      &:hover {
-        background-color: @navbar-inverse-link-hover-bg;
-      }
-    }
-
-    // Dividers (basically an hr) within the dropdown
-    .divider {
-      .nav-divider(darken(@navbar-inverse-bg, 5%));
-    }
-  }
-
   // Darken the responsive nav toggle
   .navbar-toggle {
     border-color: @navbar-inverse-toggle-border-color;
@@ -694,12 +652,7 @@
     background-color: transparent;
     color: #FFF;
 
-    &:hover:not(.open) {
-      box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.4), 0 1px 2px rgba(255, 255, 255, 0.4);
-    }
-
     &.open {
-      background-color: @gray-400;
       svg path {
         fill: #FFF;
       }
@@ -712,42 +665,6 @@
 
       &__current_option {
         color: #FFF;
-      }
-    }
-  }
-
-  global-menu-support {
-
-    .dt-gnm-menu-support-button.open {
-      .menu-button-support-icon-question path,
-      .menu-button-support-icon-arrow path {
-        fill: #FFF;
-      }
-    }
-
-    .items-list {
-      background-color: #000;
-      border-color: @gray-200;
-      box-shadow: none;
-
-      li {
-        &.divider {
-          color: @gray-200;
-        }
-
-        &.arrow {
-          border-bottom-color: @gray-200;
-          span {
-            border-bottom-color: #000;
-          }
-        }
-
-        a {
-          color: #FFF;
-          &:hover {
-            background-color: @gray-400;
-          }
-        }
       }
     }
   }
@@ -837,6 +754,58 @@
     }
   }
 
+  .navbar-account {
+
+    > li > button,
+    > li > a {
+      color: #fff;
+      background-color: transparent;
+
+      &:hover,
+      &:focus {
+        color: #fff;
+        background-color: transparent;
+
+        svg {
+          fill: @gray-200;
+        }
+      }
+    }
+
+    > .active > a {
+      &,
+      &:hover,
+      &:focus {
+        color: #fff;
+        background-color: transparent;
+      }
+    }
+
+    > .disabled > a {
+      &,
+      &:hover,
+      &:focus {
+        color: @gray-400;
+        background-color: transparent;
+      }
+    }
+
+    a:hover,
+    button:hover {
+      .cyclops-icon {
+        fill: #fff;
+      }
+    }
+
+    > .open > a {
+      &,
+      &:hover,
+      &:focus {
+        color: #fff;
+      }
+    }
+  }
+
   .navbar-link {
     color: @navbar-inverse-link-color;
 
@@ -885,6 +854,14 @@
   .cyclops-icon {
     transition: all linear 150ms;
     fill: @gray-200;
+  }
+
+  & > li > button,
+  & > li > a {
+    &:hover,
+    &:focus {
+      background-color: transparent;
+    }
   }
 
   a:hover, button:hover {

--- a/www/views/partials/navigation/examples/page-header-inverse.html
+++ b/www/views/partials/navigation/examples/page-header-inverse.html
@@ -9,7 +9,7 @@
         <span class="icon-bar"></span>
       </button>
       <a class="navbar-brand" href="/">
-        <img src="{{{block "relativePath"}}}img/CenturyLink_logo_white_text.svg" alt="CenturyLink" />
+        <img src="https://assets.ctl.io/images/centurylink-logo-white.svg" alt="CenturyLink" />
       </a>
       <a class="navbar-service" href="/">Control Portal</a>
 

--- a/www/views/partials/navigation/examples/page-header.html
+++ b/www/views/partials/navigation/examples/page-header.html
@@ -9,7 +9,7 @@
 				<span class="icon-bar"></span>
 			</button>
 			<a class="navbar-brand" href="/">
-				<img src="{{{block "relativePath"}}}img/logo-centurylink-light.svg" alt="CenturyLink" />
+				<img src="https://assets.ctl.io/images/centurylink-logo.svg" alt="CenturyLink" />
 			</a>
 			<a class="navbar-service" href="/">Control Portal</a>
 

--- a/www/views/partials/navigation/pageHeader.html
+++ b/www/views/partials/navigation/pageHeader.html
@@ -72,7 +72,7 @@
         &lt;span class=&quot;icon-bar&quot;&gt;&lt;/span&gt;
       &lt;/button&gt;
       &lt;a class=&quot;navbar-brand&quot; href=&quot;/&quot;&gt;
-        &lt;img src=&quot;/img/CenturyLink_logo_white_text.svg&quot; alt=&quot;CenturyLink&quot; /&gt;
+        &lt;img src=&quot;/https://assets.ctl.io/images/centurylink-logo-white.svg&quot; alt=&quot;CenturyLink&quot; /&gt;
       &lt;/a&gt;
       &lt;a class=&quot;navbar-service&quot; href=&quot;/&quot;&gt;Control Portal&lt;/a&gt;
     &lt;/div&gt;

--- a/www/views/partials/starter-pages/header-main-nav-inverse.html
+++ b/www/views/partials/starter-pages/header-main-nav-inverse.html
@@ -13,7 +13,7 @@
   <link href="/css/cyclops.css" rel="stylesheet" type="text/css" />
 
    <!-- Global Navigation Menu -->
-   <script src="http://assets.ctl.io/dt-GlobalNavigationMenu/1.1.0-rc.4/global-menus.js"></script>
+   <script src="https://assets.ctl.io/global-menus/2.0.3/global-menus.js"></script>
 
   <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
   <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->

--- a/www/views/partials/starter-pages/header-main-nav.html
+++ b/www/views/partials/starter-pages/header-main-nav.html
@@ -13,7 +13,7 @@
   <link href="/css/cyclops.css" rel="stylesheet" type="text/css" />
    
    <!-- Global Navigation Menu -->
-   <script src="http://assets.ctl.io/dt-GlobalNavigationMenu/1.1.0-rc.4/global-menus.js"></script>
+   <script src="https://assets.ctl.io/global-menus/2.0.3/global-menus.js"></script>
 
   <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
   <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->


### PR DESCRIPTION
Fixed Cyclops inverse menu drop-down (navbar-account) colors to match Chi. 

@mattnickles , @jllr please review. It won't work until Global Navigation Menu version 2.0.3 is released, as this Cyclops version depends on that Global Navigation Menu version. 